### PR TITLE
fix(front): Designate `client_max_body_size`  in Nginx

### DIFF
--- a/front/server-config/nginx.conf
+++ b/front/server-config/nginx.conf
@@ -30,4 +30,8 @@ http {
     gzip                on;
 
     include             /etc/nginx/conf.d/*.conf;
+
+    client_body_buffer_size 20m;
+
+    client_max_body_size    20m;
 }


### PR DESCRIPTION
Under our test, when the web admin tries to post a large image,
which may become over 1MB after encoding, the posting fails. T-
his is because file upload size in Nginx is limited to 1MB by
default. So we adjusted the limit to 20MB, in order to fit the
requirement from the front.