### PR TITLE
fix: Reset client buffer size

### DIFF
--- a/front/server-config/nginx.conf
+++ b/front/server-config/nginx.conf
@@ -29,5 +29,9 @@ http {
 
     gzip                on;
 
+    client_body_buffer_size 16k;
+
+    client_max_body_size    20m;
+
     include             /etc/nginx/conf.d/*.conf;
 }

--- a/front/server-config/nginx.conf
+++ b/front/server-config/nginx.conf
@@ -29,7 +29,7 @@ http {
 
     gzip                on;
 
-    client_body_buffer_size 16k;
+    client_body_buffer_size 8k;
 
     client_max_body_size    20m;
 


### PR DESCRIPTION
I reset it to 8k, because larger buffer size would ease DDoS attack vectors.
