### PR TITLE
Modify docker setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore all files started by dot.
+.*
+!.gitignore

--- a/README.md
+++ b/README.md
@@ -6,10 +6,27 @@ ACMHomepage is a Homepage for ACMer.
 
 This section is used to build and run the service. Not for testing.
 
-The only thing you need is just Docker.
+The only requirement is Docker.
 
-```shell
-docker compose build
-docker compose up
-```
+1. The first thing you should do is build the compose:
+
+   ```shell
+   docker compose build
+   ```
+
+   If Go cannot download the dependencies modules, you can try setting the
+   `GOPROXY` build argument:
+
+   ```shell
+   docker compose build --build-arg GOPROXY=<proxy-url>
+   ```
+
+   You can find useful information on the Internet regarding setting a proxy for
+   Go.
+
+2. Run the service by using the following command:
+
+   ```
+   docker compose up
+   ```
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.19
 
 WORKDIR /usr/src/app
 
-ENV GOPROXY https://goproxy.cn
+ARG GOPROXY
 
 # Download the modules.
 COPY go.mod go.sum ./

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,8 @@ FROM golang:1.19
 
 WORKDIR /usr/src/app
 
+ENV GOPROXY https://goproxy.cn
+
 # Download the modules.
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: postgres:15.1
     restart: always
     environment:
+      - "PGUSER=postgres"
       - "POSTGRES_PASSWORD=password"
       - "POSTGRES_DB=backend"
     volumes:


### PR DESCRIPTION
- Solve network problems with `docker compose build`: to add proxy for go
- Solve the PostgreSQL error in `docker compose up`: role "root" does not exist ([solution](https://stackoverflow.com/questions/60193781/postgres-with-docker-compose-gives-fatal-role-root-does-not-exist-error))

---

+ 解决 `docker compose build` 出现的网络问题：为 go 添加国内代理
+ 解决 `docker compose up` 出现的 PostgreSQL 报错： `role "root" does not exist` ([解决方案](https://stackoverflow.com/questions/60193781/postgres-with-docker-compose-gives-fatal-role-root-does-not-exist-error))